### PR TITLE
PIPE-111 Fix/pipe created first

### DIFF
--- a/pipert2/core/base/pipe.py
+++ b/pipert2/core/base/pipe.py
@@ -171,7 +171,23 @@ class Pipe:
         flow_validator.validate_flow(self.flows, self.wires)
         wires_validator.validate_wires(self.wires.values())
 
-    def _send_initial_log(self):
+    def get_pipe_structure(self):
+        """Calculate the structure of the pipe including the routines and the events.
+
+        Returns:
+            Dictionary of routines details, and custom events the pipe supported.
+            {
+                Routines: [
+                    {
+                        flow_name: xxx,
+                        routine_name: xxx,
+                        events: []
+                    }
+                ],
+                Events: []
+            }
+        """
+
         flows_routines = []
 
         for flow in self.flows.values():
@@ -189,6 +205,15 @@ class Pipe:
             'Routines': flows_routines,
             'Events': [START_EVENT_NAME, STOP_EVENT_NAME, KILL_EVENT_NAME]
         }
+
+        return creation_log
+
+    def _send_initial_log(self):
+        """Send initial log with the structure of the pipeline.
+
+        """
+
+        creation_log = self.get_pipe_structure()
 
         self.logger.handlers[0].log_event_name = CREATION_LOG_NAME
         self.logger.info(creation_log)

--- a/pipert2/core/wrappers/api_wrapper.py
+++ b/pipert2/core/wrappers/api_wrapper.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import flask
 from flask import Flask
 from flask import Response
@@ -18,11 +20,13 @@ class APIWrapper:
         """
 
         self.notify_callback = pipe.get_event_notify()
+        self.pipe = pipe
 
         self.app = Flask(__name__)
         self.app.add_url_rule("/start", "start", self.start, methods=['POST'])
         self.app.add_url_rule("/pause", "pause", self.pause, methods=['POST'])
         self.app.add_url_rule("/kill", "kill", self.kill, methods=['POST'])
+        self.app.add_url_rule("/pipe/structure", "pipe_structure", self.get_pipe_structure, methods=['GET'])
 
         self.app.add_url_rule("/routines/<routine_name>/events/<event_name>/execute/",
                               "routine_execute",
@@ -80,6 +84,24 @@ class APIWrapper:
             shutdown_hook()
 
         return Response(status=200)
+
+    def get_pipe_structure(self):
+        """Get the structure of the pipeline with the events its including.
+
+        Returns:
+            Dictionary of routines details, and custom events the pipe supported.
+            {
+                Routines: [
+                    {
+                        flow_name: xxx,
+                        routine_name: xxx,
+                        events: []
+                    }
+                ],
+                Events: []
+            }
+        """
+        return self.pipe.get_pipe_structure()
 
     def routine_execute(self, routine_name, event_name):
         """Execute custom event. Should get request with 'event_name' and with optional keys parameters.

--- a/pipert2/core/wrappers/api_wrapper.py
+++ b/pipert2/core/wrappers/api_wrapper.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import flask
 from flask import Flask
 from flask import Response

--- a/pipert2/utils/socketio_logger/socket_handler.py
+++ b/pipert2/utils/socketio_logger/socket_handler.py
@@ -2,6 +2,8 @@ import logging
 import socketio
 from socketio.exceptions import SocketIOError
 
+from pipert2.utils.consts.emit_socket_names import LOG_NAME
+
 
 class SocketHandler(logging.Handler):
     def __init__(self, url, log_event_name):
@@ -13,7 +15,10 @@ class SocketHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         if not self.sio.connected:
-            self.sio.connect(self.url)
+            try:
+                self.sio.connect(self.url)
+            except socketio.exceptions.ConnectionError:
+                return
         try:
             self.sio.emit(self.log_event_name, self.formatter.format(record))
         except SocketIOError:

--- a/pipert2/utils/socketio_logger/socket_handler.py
+++ b/pipert2/utils/socketio_logger/socket_handler.py
@@ -2,8 +2,6 @@ import logging
 import socketio
 from socketio.exceptions import SocketIOError
 
-from pipert2.utils.consts.emit_socket_names import LOG_NAME
-
 
 class SocketHandler(logging.Handler):
     def __init__(self, url, log_event_name):

--- a/tests/unit/pipert/core/wrappers/test_api_wrapper.py
+++ b/tests/unit/pipert/core/wrappers/test_api_wrapper.py
@@ -18,7 +18,7 @@ def api_wrapper_with_mock_notify(mocker: MockerFixture):
 
 
 def test_get_pipe_structure(api_wrapper_with_mock_notify):
-    api_wrapper_with_mock_notify.get_pipe_structure()
+    _ = api_wrapper_with_mock_notify.get_pipe_structure()
 
     api_wrapper_with_mock_notify.pipe.get_pipe_structure.assert_called_once()
 

--- a/tests/unit/pipert/core/wrappers/test_api_wrapper.py
+++ b/tests/unit/pipert/core/wrappers/test_api_wrapper.py
@@ -17,6 +17,12 @@ def api_wrapper_with_mock_notify(mocker: MockerFixture):
     return api_wrapper
 
 
+def test_get_pipe_structure(api_wrapper_with_mock_notify):
+    api_wrapper_with_mock_notify.get_pipe_structure()
+
+    api_wrapper_with_mock_notify.pipe.get_pipe_structure.assert_called_once()
+
+
 def test_run(api_wrapper_with_mock_notify, mocker: MockerFixture):
 
     api_wrapper_with_mock_notify.api_process = mocker.MagicMock()


### PR DESCRIPTION
I chose to create new 'GET' route to return the pipe's structure. 
One of the reasons we can't reuse the `send_initial_log` it's because while the pipe is running, a multiple logs are sending and in the `send_initial_log` function there is a change of the log name to creation log name, where regular logs can send with this log name and cause multiple exceptions. 
I reused the way we create the initial log, but not the way we send it to the cockpit. 
So new function with new route, and without any dependencies it's the best solution I came up with. 